### PR TITLE
Skip hooking (nested) widgets without table definition (on first level)

### DIFF
--- a/src/EventListener/Contao/Hooks/ParseWidgetListener.php
+++ b/src/EventListener/Contao/Hooks/ParseWidgetListener.php
@@ -37,7 +37,7 @@ class ParseWidgetListener
     #[AsHook(hook: 'parseWidget')]
     public function onParseWidget(string $buffer, Widget $widget): string
     {
-        if (!$widget->dataContainer) {
+        if (!$widget->dataContainer || !$widget->dataContainer->table) {
             return $buffer;
         }
 


### PR DESCRIPTION
Fixes #10 

Ich habe doch mal die Zeit gefunden, mein Problem zu debuggen.

Das Problem war gar nicht direkt die Extension `cgoit/calendar-extended-bundle`, sondern die Abhängigkeit `menatwork/contao-multicolumnwizard-bundle`  bzw. dessen Nutzung.

Das verwendete `MultiColumnWizard`-Widget ist wohl ein mehrdimensionaler Container, der selbst keine Tabellen-Referenz gesetzt hat (-> `$widget->dataContainer->table ~= null`). Erst wenn man wiederum auf dessen `dataContainer` zugreift, erhält man die zugehörige Tabelle.

<details>
<summary>Hier ein Dump vom `$widget` Objekt, wie es in der `onParseWidget`-Funktion ankommt (bis der Output wegen zu tiefer Nestung/Rekursion abbricht).</summary> 

```
Repeat event (irregular)
xdebug://debug-eval:1:
object(Contao\TextField)[2992]
  protected 'arrObjects' => 
    array (size=1)
      'Config' => 
        object(Contao\Config)[979]
          protected 'strTop' => string '' (length=0)
          protected 'strBottom' => string '' (length=0)
          protected 'blnIsModified' => boolean false
          protected 'arrData' => 
            array (size=0)
          protected 'arrCache' => 
            array (size=0)
          protected 'strRootDir' => string '/var/www/html' (length=13)
  protected 'strId' => string 'repeatFixedDates_row0_new_repeat' (length=32)
  protected 'strName' => string 'repeatFixedDates[0][new_repeat]' (length=31)
  protected 'strLabel' => string 'Date' (length=4)
  protected 'varValue' => string '' (length=0)
  protected 'inputCallback' => null
  protected 'strClass' => null
  protected 'strPrefix' => null
  protected 'strWizard' => null
  protected 'arrErrors' => 
    array (size=0)
      empty
  protected 'arrAttributes' => 
    array (size=1)
      'style' => string 'width:100px' (length=11)
  protected 'arrConfiguration' => 
    array (size=15)
      'rgxp' => string 'date' (length=4)
      'datepicker' => boolean true
      'doNotCopy' => boolean true
      'tl_class' => string 'wizard hidelabel mcwUpdateFields' (length=32)
      'required' => boolean false
      'tableless' => boolean true
      'strField' => null
      'strTable' => string 'tl_calendar_events' (length=18)
      'description' => null
      'type' => string 'text' (length=4)
      'allowHtml' => boolean false
      'storeValues' => boolean true
      'xlabel' => string '' (length=0)
      'currentRecord' => string '34' (length=2)
      'mandatoryField' => string 'Mandatory field' (length=15)
  protected 'arrOptions' => 
    array (size=0)
      empty
  protected 'blnSubmitInput' => boolean true
  protected 'blnForAttribute' => boolean true
  protected 'objDca' => 
    object(MenAtWork\MultiColumnWizardBundle\Contao\Widgets\MultiColumnWizard)[2964]
      protected 'arrObjects' => 
        array (size=2)
          'Config' => 
            object(Contao\Config)[979]
              ...
          'calendar_extended.mcw.callbacks' => 
            object(Cgoit\CalendarExtendedBundle\EventListener\DataContainer\CalendarEventsMCWCallbacks)[2996]
              ...
      protected 'strId' => string 'repeatFixedDates' (length=16)
      protected 'strName' => string 'repeatFixedDates' (length=16)
      protected 'strLabel' => string 'Repeat event (irregular)' (length=24)
      protected 'varValue' => 
        array (size=1)
          0 => 
            array (size=4)
              ...
      protected 'inputCallback' => null
      protected 'strClass' => null
      protected 'strPrefix' => null
      protected 'strWizard' => null
      protected 'arrErrors' => 
        array (size=0)
          empty
      protected 'arrAttributes' => 
        array (size=0)
          empty
      protected 'arrConfiguration' => 
        array (size=12)
          'required' => boolean false
          'strField' => string 'repeatFixedDates' (length=16)
          'strTable' => string 'tl_calendar_events' (length=18)
          'description' => string 'Create a irregular recurring event.' (length=35)
          'type' => string 'multiColumnWizard' (length=17)
          'allowHtml' => boolean false
          'columnFields' => 
            array (size=4)
              ...
          'xlabel' => string '' (length=0)
          'currentRecord' => string '34' (length=2)
          'mandatoryField' => string 'Mandatory field' (length=15)
          'strCommand' => string 'cmd_repeatFixedDates' (length=20)
          'activeRow' => int 0
      protected 'arrOptions' => 
        array (size=0)
          empty
      protected 'blnSubmitInput' => boolean true
      protected 'blnForAttribute' => boolean false
      protected 'objDca' => 
        object(Contao\DC_Table)[2452]
          protected 'arrObjects' => 
            array (size=2)
              ...
          protected 'intId' => string '34' (length=2)
          protected 'strTable' => string 'tl_calendar_events' (length=18)
          protected 'strField' => string 'repeatFixedDates' (length=16)
          protected 'strInputName' => string 'repeatFixedDates' (length=16)
          protected 'varValue' => string 'a:1:{i:0;a:4:{s:10:"new_repeat";s:0:"";s:9:"new_start";s:0:"";s:7:"new_end";s:0:"";s:6:"reason";s:0:"";}}' (length=105)
          protected 'strPalette' => string '{title_legend},title,featured,alias,author;{date_legend},showOnFreeDay,addTime,[addTime],ignoreEndTime,startTime,endTime,[EOF],startDate,endDate,hideOnWeekend;{source_legend},source,linkText,canonicalLink;{meta_legend},pageTitle,robots,description,serpPreview;{tags_legend},tags;{details_legend},location,address,teaser;{image_legend},addImage;{location_legend},location_name,location_str,location_ort;{contact_legend},location_link,location_contact,location_mail;{recurring_legend},recurring;{recurring_legend_e'... (length=813)
          protected 'root' => 
            array (size=0)
          protected 'rootChildren' => 
            array (size=0)
          protected 'visibleRootTrails' => 
            array (size=0)
          protected 'rootPaste' => boolean false
          protected 'procedure' => 
            array (size=1)
              ...
          protected 'values' => 
            array (size=1)
              ...
          protected 'onsubmit' => 
            array (size=0)
          protected 'noReload' => boolean false
          protected 'objActiveRecord' => 
            object(stdClass)[1939]
              ...
          protected 'blnUploadable' => boolean false
          protected 'objPicker' => null
          protected 'objPickerCallback' => null
          protected 'arrPickerValue' => 
            array (size=0)
          protected 'strPickerFieldType' => null
          protected 'blnCreateNewVersion' => boolean false
          protected 'intCurrentPid' => int 8
          protected 'ptable' => string 'tl_calendar' (length=11)
          protected 'ctable' => 
            array (size=1)
              ...
          protected 'limit' => null
          protected 'total' => null
          protected 'firstOrderBy' => null
          protected 'orderBy' => 
            array (size=0)
          protected 'set' => 
            array (size=0)
          protected 'current' => 
            array (size=0)
          protected 'treeView' => boolean false
          protected 'arrModule' => 
            array (size=3)
              ...
          protected 'arrSubmit' => 
            array (size=0)
      protected 'strTemplate' => string 'be_widget' (length=9)
      protected 'strParent' => null
      protected 'strDefault' => null
      protected 'strFormat' => string 'html5' (length=5)
      protected 'strTagEnding' => string '>' (length=1)
      protected 'arrBlocks' => 
        array (size=0)
          empty
      protected 'arrBlockNames' => 
        array (size=0)
          empty
      protected 'intBufferLevel' => int 1
      protected 'blnDebug' => null
      protected 'eventDispatcher' => 
        object(Symfony\Component\HttpKernel\Debug\TraceableEventDispatcher)[342]
          protected 'logger' => 
            object(Monolog\Logger)[339]
              ...
          protected 'stopwatch' => 
            object(Symfony\Component\Stopwatch\Stopwatch)[344]
              ...
          private ?SplObjectStorage 'callStack' (Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher) => 
            object(SplObjectStorage)[580]
              ...
          private Symfony\Component\EventDispatcher\EventDispatcherInterface 'dispatcher' (Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher) => 
            object(Symfony\Component\EventDispatcher\EventDispatcher)[343]
              ...
          private array 'wrappedListeners' (Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher) => 
            array (size=0)
          private array 'orphanedEvents' (Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher) => 
            array (size=1)
              ...
          private ?Symfony\Component\HttpFoundation\RequestStack 'requestStack' (Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher) => 
            object(Symfony\Component\HttpKernel\Debug\VirtualRequestStack)[324]
              ...
          private string 'currentRequestHash' (Symfony\Component\EventDispatcher\Debug\TraceableEventDispatcher) => string '00000000000000020000000000000000' (length=32)
      protected 'arrWidgetErrors' => 
        array (size=0)
          empty
      protected 'arrCallback' => 
        array (size=2)
          0 => string 'calendar_extended.mcw.callbacks' (length=31)
          1 => string 'listFixedDates' (length=14)
      protected 'minCount' => int 0
      protected 'maxCount' => int 0
      protected 'blnTableless' => boolean false
      protected 'arrRowSpecificData' => 
        array (size=0)
          empty
      protected 'arrButtons' => 
        array (size=5)
          'new' => string 'new.gif' (length=7)
          'delete' => string 'delete.gif' (length=10)
          'move' => boolean false
          'up' => boolean false
          'down' => boolean false
      private MenAtWork\MultiColumnWizardBundle\Service\ContaoApiService 'contaoApi' => 
        object(MenAtWork\MultiColumnWizardBundle\Service\ContaoApiService)[987]
          private Symfony\Component\HttpFoundation\RequestStack 'requestStack' => 
            object(Symfony\Component\HttpFoundation\RequestStack)[314]
              ...
          private Contao\CoreBundle\Routing\ScopeMatcher 'scopeMatcher' => 
            object(Contao\CoreBundle\Routing\ScopeMatcher)[319]
              ...
      private ?Symfony\Contracts\Translation\TranslatorInterface 'translator' => null
      private mixed 'defaultValue' => *uninitialized*
  protected 'strTemplate' => string 'be_widget' (length=9)
  protected 'strParent' => null
  protected 'strDefault' => null
  protected 'strFormat' => string 'html5' (length=5)
  protected 'strTagEnding' => string '>' (length=1)
  protected 'arrBlocks' => 
    array (size=0)
      empty
  protected 'arrBlockNames' => 
    array (size=0)
      empty
  protected 'intBufferLevel' => int 1
  protected 'blnDebug' => null
```

</details>

Ich habe in dieser PR die Wächterklausel so erweitert, dass Widgets übersprungen werden, die keine Tabelle direkt gesetzt haben. Falls solche speziellen Widgets verarbeitet werden sollen, müsste man hier ggf. stattdessen tiefer im `dataContainer` als Fallback suchen. Hier kenne ich mich mit Contao allerdings zu wenig aus, um zu wissen, ob dieses Problem häufiger vorkommt oder nur ein Einzelfall wäre, für den man wahrscheinlich keinen Sonderfall implementieren möchte.